### PR TITLE
Небольшие изменения в классе PatternArgBuilder

### DIFF
--- a/sources/libs/translation_module/src/include/translation_module/arg_builders.h
+++ b/sources/libs/translation_module/src/include/translation_module/arg_builders.h
@@ -119,22 +119,21 @@ public:
             }
         };
 
+        std::string workString{patternedString};
         while (true) {
-            StringView sw(patternedString.data(), patternedString.size());
-            auto result = findMostDeepPair(sw, '<', '>');
-
+            auto result = findMostDeepPair(workString, '<', '>');
             if (result.first) {
                 StringView &foundSubstr = result.second;
-                auto replaceFrom = std::distance(patternedString.data(), foundSubstr.data());
+                auto replaceFrom = std::distance(workString.data(), foundSubstr.data());
                 auto replaceSize = foundSubstr.size();
 
-                PatternStringInfo patternStringInfo(std::string(foundSubstr.data() + 1, foundSubstr.size() - 2));
+                PatternStringInfo patternStringInfo{std::string(foundSubstr.data() + 1, foundSubstr.size() - 2)};
 
                 auto p = storage.srcArgString.find(patternStringInfo.getNameWithGroup());
                 if (p != storage.srcArgString.end()) {
                     const std::string &newValue = p->second;
 
-                    patternedString.replace(replaceFrom, replaceSize, newValue);
+                    workString.replace(replaceFrom, replaceSize, newValue);
                     continue;
                 }
 
@@ -142,19 +141,19 @@ public:
                 if (replacer != storage.replacers.end()) {
                     const std::string &newValue = replacer->second(patternStringInfo);
 
-                    patternedString.replace(replaceFrom, replaceSize, newValue);
+                    workString.replace(replaceFrom, replaceSize, newValue);
                     continue;
                 }
 
                 throw std::runtime_error("Нет замены для шаблона " + patternStringInfo.getName());
             } else {
-                return packer->pack(std::string(sw.data(), sw.size()));
+                return packer->pack(workString);
             }
         }
     }
 
     PackerPtr packer;
-    std::string patternedString;
+    const std::string patternedString;
     const CmdTranslatorStorage &storage;
 };
 


### PR DESCRIPTION
Сделал `patternedString` константой, чтобы можно было повторно вызывать функцию `createArg` у класса `PatternArgBuilder`