### PR TITLE
Небольшие правки в  TranslationModule

### DIFF
--- a/sources/im2_im3/dvyyaz.cpp
+++ b/sources/im2_im3/dvyyaz.cpp
@@ -11,7 +11,7 @@ void Dvyyaz::preprocess(JSON &cmds) {}
 
 void Dvyyaz::postprocess(JSON &cmds) {}
 
-const trm::Replacers &Dvyyaz::getReplacers(const JSON &cmds)
+trm::Replacers &Dvyyaz::getReplacers(const JSON &cmds)
 {
     static trm::Replacers replacers;
     return replacers;

--- a/sources/im2_im3/dvyyaz.h
+++ b/sources/im2_im3/dvyyaz.h
@@ -10,7 +10,7 @@ private:
     virtual void preprocess(JSON &cmds) override;
     virtual void postprocess(JSON &cmds) override;
 
-    virtual const trm::Replacers &getReplacers(const JSON &cmds) override;
+    virtual trm::Replacers &getReplacers(const JSON &cmds) override;
     virtual std::string getRules() override;
 };
 

--- a/sources/im3_im4/steckoyaz.cpp
+++ b/sources/im3_im4/steckoyaz.cpp
@@ -10,7 +10,7 @@ void Steckoyaz::preprocess(JSON &cmds) {}
 
 void Steckoyaz::postprocess(JSON &cmds) {}
 
-const trm::Replacers &Steckoyaz::getReplacers(const JSON &cmds)
+trm::Replacers &Steckoyaz::getReplacers(const JSON &cmds)
 {
     static trm::Replacers replacers;
     return replacers;

--- a/sources/im3_im4/steckoyaz.h
+++ b/sources/im3_im4/steckoyaz.h
@@ -9,7 +9,7 @@ private:
     virtual void preprocess(JSON &cmds) override;
     virtual void postprocess(JSON &cmds) override;
 
-    virtual const trm::Replacers &getReplacers(const JSON &cmds) override;
+    virtual trm::Replacers &getReplacers(const JSON &cmds) override;
     virtual std::string getRules() override;
 };
 

--- a/sources/im4_im5/complexoyaz.cpp
+++ b/sources/im4_im5/complexoyaz.cpp
@@ -11,7 +11,7 @@ void Complexoyaz::preprocess(JSON &cmds) {}
 
 void Complexoyaz::postprocess(JSON &cmds) {}
 
-const trm::Replacers &Complexoyaz::getReplacers(const JSON &cmds)
+trm::Replacers &Complexoyaz::getReplacers(const JSON &cmds)
 {
     static trm::Replacers replacers;
     return replacers;

--- a/sources/im4_im5/complexoyaz.h
+++ b/sources/im4_im5/complexoyaz.h
@@ -10,7 +10,7 @@ private:
     virtual void preprocess(JSON &cmds) override;
     virtual void postprocess(JSON &cmds) override;
 
-    virtual const trm::Replacers &getReplacers(const JSON &cmds) override;
+    virtual trm::Replacers &getReplacers(const JSON &cmds) override;
     virtual std::string getRules() override;
 };
 

--- a/sources/libs/translation_module/src/include/translation_module/translation_module.h
+++ b/sources/libs/translation_module/src/include/translation_module/translation_module.h
@@ -21,7 +21,7 @@ private:
     virtual void process(JSON &cmds) final;
     virtual void postprocess(JSON &cmds) = 0;
 
-    virtual const Replacers &getReplacers(const JSON &cmds) = 0;
+    virtual Replacers &getReplacers(const JSON &cmds) = 0;
     virtual std::string getRules() = 0;
 };
 

--- a/sources/libs/translation_module/src/src/translation_module.cpp
+++ b/sources/libs/translation_module/src/src/translation_module.cpp
@@ -1,4 +1,5 @@
 #include "translation_module.h"
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -73,7 +74,10 @@ CmdTranslators getCmdTranslators(const std::string &rules, const Replacers &repl
 
     std::istringstream rulesStream(rules);
     std::string line;
+    size_t lineNo = 0;
     while (std::getline(rulesStream, line)) {
+        ++lineNo;
+
         // пропускаем пустые строки и комментариии
         sutils::lrstrip(line);
         if (line.empty() || line.front() == '#') {
@@ -87,10 +91,9 @@ CmdTranslators getCmdTranslators(const std::string &rules, const Replacers &repl
         std::getline(rulesStream, line);
         sutils::lrstrip(line);
         if (line != "=>") {
-            throw std::runtime_error("Формат файла с правилами трансляции нарушен.");
+            throw std::runtime_error("Формат файла с правилами трансляции нарушен, строка: " + std::to_string(lineNo));
         }
-
-        // считываем набор команд
+// считываем набор команд
         std::vector<CmdInfo> dstCmds;
         while (std::getline(rulesStream, line)) {
             sutils::lrstrip(line);
@@ -104,7 +107,8 @@ CmdTranslators getCmdTranslators(const std::string &rules, const Replacers &repl
         auto p = cmdTranslators.emplace(std::piecewise_construct, std::forward_as_tuple(srcCmd),
                                         std::forward_as_tuple(srcCmd, dstCmds, replacers));
         if (!p.second) {
-            throw std::runtime_error("Команда для трансляции повторяется более одного раза.");
+            throw std::runtime_error("Команда для трансляции повторяется более одного раза, строка: " +
+                                     std::to_string(lineNo));
         }
     }
 

--- a/sources/libs/translation_module/tests/translator_fixture.cpp
+++ b/sources/libs/translation_module/tests/translator_fixture.cpp
@@ -16,7 +16,7 @@ void TranslatorFixture::preprocess(JSON &cmds) {}
 
 void TranslatorFixture::postprocess(JSON &cmds) {}
 
-const trm::Replacers &TranslatorFixture::getReplacers(const JSON &cmds)
+trm::Replacers &TranslatorFixture::getReplacers(const JSON &cmds)
 {
     static trm::Replacers replacers;
     return replacers;

--- a/sources/libs/translation_module/tests/translator_fixture.h
+++ b/sources/libs/translation_module/tests/translator_fixture.h
@@ -13,7 +13,7 @@ private:
     virtual void preprocess(JSON &cmds) override;
     virtual void postprocess(JSON &cmds) override;
 
-    virtual const trm::Replacers &getReplacers(const JSON &cmds) override;
+    virtual Replacers &getReplacers(const JSON &cmds) override;
     virtual std::string getRules() override;
 
     std::string rules;


### PR DESCRIPTION
* Убрал константность TranslationModule::getReplacers()
* Сделал ошибки парсинга прав транссляции более информативными