### PR TITLE
Трансляция аргументов в командах

### DIFF
--- a/sources/im4_im5/complexoyaz.cpp
+++ b/sources/im4_im5/complexoyaz.cpp
@@ -1,6 +1,8 @@
 #include "complexoyaz.h"
 #include <memory>
+#include <regex>
 #include <stdexcept>
+#include <translation_module/args_range.h>
 #include <translation_module/replacers.h>
 #include "functional_replacers.h"
 
@@ -43,7 +45,70 @@ bool Complexoyaz::valid(const JSON &cmds, std::string &error)
 
 void Complexoyaz::preprocess(JSON &cmds) {}
 
-void Complexoyaz::postprocess(JSON &cmds) {}
+void Complexoyaz::postprocess(JSON &cmds)
+{
+    cmds = processFunctions(cmds);
+
+    trm::Filters filters{
+        {"definition_string", {trm::ArgsFilter::Ignore::SOME, {0}}},
+        {"asm", {trm::ArgsFilter::Ignore::ALL}},
+        {"error", {trm::ArgsFilter::Ignore::ALL}},
+    };
+
+    for (JSON &cmd : cmds) {
+        trm::ArgsRange range{filters, cmd};
+        for (auto &arg : range) {
+            if (arg->isString()) {
+                const std::string argStr = arg->asString();
+
+                //
+                // замена L1 => L1_buffer
+                //        F1 => F1_buffer
+                //
+                static const std::regex isComplex("[LF][0-9]+");
+                std::smatch match;
+                if (std::regex_match(argStr, match, isComplex) && match.size() == 1) {
+                    *arg = argStr + "_buffer";
+                    break;
+                }
+
+                //
+                // замена L1[i] => L1_buffer[i]
+                //        F1[i] => F1_buffer[i]
+                //
+                static const std::regex isComplexWithIndex(R"(([LF][0-9]+)(\[[^\]]*\]))");
+                if (std::regex_match(argStr, match, isComplexWithIndex) && match.size() == 3) {
+                    std::string prefix = calculateElementSize(argStr) + "byte";
+                    *arg = prefix + " " + match[1].str() + "_buffer" + match[2].str();
+                    break;
+                }
+
+                //
+                // FIXME: Q<N> и S<N> транслируются
+                // с ошибкой для комплексов F<N>
+                //
+
+                //
+                // замена Q1[i] => 8byte L1_struct[0]
+                //
+                static const std::regex isCardinality("Q[0-9]+");
+                if (std::regex_match(argStr, match, isCardinality) && match.size() == 1) {
+                    *arg = "8byte " + argStr + "_struct[0]";
+                    break;
+                }
+
+                //
+                // замена S1[i] => 8byte L1_struct[1]
+                //
+                static const std::regex isCapacity("S[0-9]+");
+                if (std::regex_match(argStr, match, isCapacity) && match.size() == 1) {
+                    *arg = "8byte " + argStr + "_struct[1]";
+                    break;
+                }
+            }
+        }
+    }
+}
 
 trm::Replacers Complexoyaz::makeReplacers()
 {
@@ -89,6 +154,72 @@ std::string Complexoyaz::getRules()
     return std::string(
 #include "rules.txt"
     );
+}
+
+JSON Complexoyaz::processFunctions(JSON &cmds)
+{
+    // definition func(a,L1/c,F2)
+    // =>
+    // definition func(a,L1_struct/c,F2_struct)
+    // move L1_buffer, L1_struct[2]
+    // move F2_buffer, F2_struct[2]
+
+    // call func(a,L1/c,F2)
+    // =>
+    // call func(a,L1_struct/c,F2_struct)
+    // move L1_buffer, L1_struct[2]
+    // move F2_buffer, F2_struct[2]
+
+    JSON result;
+
+    for (JSON &cmd : cmds) {
+        LCC_ASSERT(cmd.isMember("type"));
+        std::string type = cmd["type"].asString();
+
+        if (!cmd.isMember("args")) {
+            result.append(cmd);
+            continue;
+        }
+        JSON &args = cmd["args"];
+
+        std::vector<JSON> postCmds;
+        auto processor = [&postCmds](const JSON &arg) -> JSON {
+            if (!arg.isString()) {
+                return arg;
+            }
+            const std::string &argStr = arg.asString();
+
+            static const std::regex isComplex("[LF][0-9]+");
+            std::smatch match;
+            if (std::regex_match(argStr, match, isComplex) && match.size() == 1) {
+                JSON args;
+                args.append(argStr + "_buffer");
+                args.append("8byte " + argStr + "_struct[2]");
+
+                JSON moveCmd;
+                moveCmd["type"] = "cmd";
+                moveCmd["cmd"] = "move";
+                moveCmd["args"] = std::move(args);
+
+                postCmds.push_back(std::move(moveCmd));
+
+                return argStr + "_struct";
+            }
+
+            return arg;
+        };
+
+        if (type == "definition" || type == "call") {
+            std::transform(std::begin(args), std::end(args), std::begin(args), processor);
+        }
+
+        result.append(cmd);
+        for (auto &c : postCmds) {
+            result.append(c);
+        }
+    }
+
+    return result;
 }
 
 }  // namespace cyaz

--- a/sources/im4_im5/complexoyaz.h
+++ b/sources/im4_im5/complexoyaz.h
@@ -12,6 +12,8 @@ private:
 
     virtual trm::Replacers makeReplacers() override;
     virtual std::string getRules() override;
+
+    JSON processFunctions(JSON &cmds);
 };
 
 }  // namespace cyaz

--- a/sources/libs/translation_module/src/translation_module/args_range.h
+++ b/sources/libs/translation_module/src/translation_module/args_range.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <shared_utils/assertion.h>
+#include <translation_module/aliases.h>
+
+namespace trm {
+
+struct ArgsFilter {
+    enum class Ignore {
+        ALL,
+        SOME,
+    };
+
+    Ignore ignore;
+    std::set<size_t> ignoreArgs;
+};
+
+using Filters = std::unordered_map<std::string, ArgsFilter>;
+
+class ArgsRange {
+public:
+    ArgsRange(const Filters &filters, JSON &cmd)
+    {
+        if (!cmd.isObject()) {
+            return;
+        }
+
+        //
+        // проверяем содержимое команды
+        //
+        bool isCmd = cmd.isMember("type") && cmd["type"] == "cmd" && cmd.isMember("cmd") && cmd["cmd"].isString();
+        bool hasArgs = cmd.isMember("args");
+        if (!isCmd || !hasArgs) {
+            return;
+        }
+
+        // ищем фильтр
+        JSON &args = cmd["args"];
+        const std::string cmdName = cmd["cmd"].asString();
+        auto found = filters.find(cmdName);
+        if (found == filters.end()) {
+            std::transform(std::begin(args), std::end(args), std::back_inserter(filteredArgs), std::addressof<JSON>);
+            return;
+        }
+        const ArgsFilter &filter = found->second;
+
+        // фильтруем аргументы
+        switch (filter.ignore) {
+        case ArgsFilter::Ignore::ALL:
+            break;
+        case ArgsFilter::Ignore::SOME: {
+            for (int i = 0; i < args.size(); ++i) {
+                auto found = filter.ignoreArgs.find(i);
+                if (found == filter.ignoreArgs.end()) {
+                    filteredArgs.push_back(&args[i]);
+                }
+            }
+            break;
+        }
+        default:
+            throw std::logic_error{"Unexpected case"};
+        }
+    }
+
+    auto begin()
+    {
+        return filteredArgs.begin();
+    }
+
+    auto end()
+    {
+        return filteredArgs.end();
+    }
+
+    std::vector<JSON *> filteredArgs;
+};
+
+}  // namespace trm

--- a/sources/libs/translation_module/tests/CMakeLists.txt
+++ b/sources/libs/translation_module/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${PROJECT_NAME}
     translator_fixture.cpp
     labels_counter.cpp
     variables_counter.cpp
+    args_range.cpp
 )
 target_link_libraries(${PROJECT_NAME}
     ${LIB_NAME}

--- a/sources/libs/translation_module/tests/args_range.cpp
+++ b/sources/libs/translation_module/tests/args_range.cpp
@@ -1,0 +1,116 @@
+#include <gtest/gtest.h>
+#include <tests_utils/json_parse.h>
+#include <translation_module/args_range.h>
+
+namespace trm {
+
+TEST(ArgsRange, usage)
+{
+    Filters filters{{"concat", {ArgsFilter::Ignore::ALL}},
+                    {"definition", {ArgsFilter::Ignore::SOME, {0}}},
+                    {"test_cmd", {ArgsFilter::Ignore::SOME, {0, 2}}}};
+
+    //
+    // в команде фильтруется первый аргумент
+    //
+    {
+        Json::Value cmd = tests::parse(R"(
+            {
+                "type": "cmd",
+                "cmd": "definition",
+                "args": ["func", "a", "/", "b"]
+            }
+        )");
+        ArgsRange range{filters, cmd};
+        std::vector<JSON *> args{range.begin(), range.end()};
+        ASSERT_EQ(3, args.size());
+        ASSERT_EQ("a", args[0]->asString());
+        ASSERT_EQ("/", args[1]->asString());
+        ASSERT_EQ("b", args[2]->asString());
+    }
+
+    //
+    // в команде фильтруются все аргументы
+    //
+    {
+        Json::Value cmd = tests::parse(R"(
+            {
+                "type": "cmd",
+                "cmd": "concat",
+                "args": ["Hello, ", "world!"]
+            }
+        )");
+        ArgsRange range{filters, cmd};
+        std::vector<JSON *> args{range.begin(), range.end()};
+        ASSERT_TRUE(args.empty());
+    }
+
+    //
+    // JSON не является командой
+    //
+    {
+        Json::Value cmd = tests::parse(R"(
+            {
+                "type": "label",
+                "number": 1
+            }
+        )");
+        ArgsRange range{filters, cmd};
+        std::vector<JSON *> args{range.begin(), range.end()};
+        ASSERT_TRUE(args.empty());
+    }
+
+    //
+    // в команде фильтруются первый и третий аргументы
+    //
+    {
+        Json::Value cmd = tests::parse(R"(
+            {
+                "type": "cmd",
+                "cmd": "test_cmd",
+                "args": ["a", "b", "c"]
+            }
+        )");
+        ArgsRange range{filters, cmd};
+        std::vector<JSON *> args{range.begin(), range.end()};
+        ASSERT_EQ(1, args.size());
+        ASSERT_EQ("b", args[0]->asString());
+    }
+
+    //
+    // команда отсутствует в фильтрах
+    //
+    {
+        Json::Value cmd = tests::parse(R"(
+            {
+                "type": "cmd",
+                "cmd": "another_cmd",
+                "args": ["a", "b"]
+            }
+        )");
+        ArgsRange range{filters, cmd};
+        std::vector<JSON *> args{range.begin(), range.end()};
+        ASSERT_EQ(2, args.size());
+        ASSERT_EQ("a", args[0]->asString());
+        ASSERT_EQ("b", args[1]->asString());
+    }
+
+    //
+    // в команде фильтруются первый и третий аргументы,
+    // но аргументы отсутствуют
+    //
+    {
+        Json::Value cmd = tests::parse(R"(
+            {
+                "type": "cmd",
+                "cmd": "test_cmd",
+                "args": []
+            }
+        )");
+        ArgsRange range{filters, cmd};
+        std::vector<JSON *> args{range.begin(), range.end()};
+        ASSERT_TRUE(args.empty());
+    }
+}
+
+}  // namespace trm


### PR DESCRIPTION
Реализована трансляция аргументов L<N>, F<N>, L<N>[i], F<N>[i], Q<N>, S<N>, а также аргументов-комплексов в командах definition и call.