### PR TITLE
issue-93: [-] исправлен баг с экранированием

### DIFF
--- a/examples/test_complexes_alloc.lyapas
+++ b/examples/test_complexes_alloc.lyapas
@@ -7,9 +7,7 @@ print(a/)
 **
 
 println(/)
-    @+F1(1)
-    10@>F1
-    /F1>C
+    /'\n'>C
 **
 
 test_dealloc_and_realloc(/)

--- a/examples/test_escaping_chars.lyapas
+++ b/examples/test_escaping_chars.lyapas
@@ -1,0 +1,3 @@
+main(/)
+    /'slash\\quote\'tab\tnewline\n'>C
+    **

--- a/examples/test_operations.lyapas
+++ b/examples/test_operations.lyapas
@@ -7,9 +7,7 @@ print(a/)
 **
 
 println(/)
-    @+F1(1)
-    10@>F1
-    /F1>C
+    /'\n'>C
 **
 
 test_set_min_and_set_max(/)

--- a/lcc.sh
+++ b/lcc.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 dir=false
 allim=false

--- a/sources/im0_im1/im0_im1.y
+++ b/sources/im0_im1/im0_im1.y
@@ -1533,18 +1533,21 @@ int main(int argc, char *argv[]) {
     json_error_t json_err;
     program = json_loadf(stdin, 0, &json_err);
     if (!program) {
-        fprintf(stderr, "Ircorrect JSON\n");
-        return 0;
+        fprintf(stderr, "Invalid JSON\n");
+        return 1;
     }
     if (json_typeof(program) != JSON_ARRAY) {
-        fprintf(stderr, "Ircorrect JSON\n");
-        return 0;
+        fprintf(stderr, "JSON must be array\n");
+        return 1;
     }
     program_size = json_array_size(program);
     result = json_array();
     int retcode;
     retcode = yyparse();
-    print_json(result);
-    
+
+    size_t flags = JSON_INDENT(4);
+    char * resultJson = json_dumps(result, flags);
+    printf("%s", resultJson);
+    free(resultJson);
     return retcode;
 }

--- a/sources/im7_im8/assembler.cpp
+++ b/sources/im7_im8/assembler.cpp
@@ -27,6 +27,22 @@ const std::regex isIrPtr(R"(([18]byte) ([^\[]+)\[([^\]]+)\])");
 // пример: QWORD [ptr + offset]
 const std::regex isAsmPtr(R"(([^ ]+) \[([^\]]+)\])");
 
+std::string escape(const std::string &in)
+{
+    std::string out;
+    out.reserve(in.size());
+    for (char c : in) {
+        if (c == '\'' || c == '\\' || c == '\n' || c == '\t') {
+            out += "',";
+            out += std::to_string((unsigned)c);
+            out += ",'";
+        } else {
+            out.push_back(c);
+        }
+    }
+    return out;
+}
+
 }
 
 bool Assembler::valid(const JSON &cmds, std::string &error)
@@ -58,7 +74,7 @@ void Assembler::preprocess(JSON &cmds)
     for (auto &str : strings) {
         const std::string &name = str.second;
         const std::string &content = str.first;
-        program.push_back(makeCmd(name, {"db '" + content + "'"}));
+        program.push_back(makeCmd(name, {"db '" + escape(content) + "'"}));
     }
 
     //

--- a/sources/lyapas_im0/lyapas_im0.l
+++ b/sources/lyapas_im0/lyapas_im0.l
@@ -147,6 +147,25 @@ uint64 HexToInt(const char *hex)
     return answ;
 }
 
+void processSingleQuote(char *str)
+{
+    if (!str) {
+        return;
+    }
+
+    char *p = str;
+    while (*p != '\0') {
+        if (*p == '\\' && *(p + 1) == '\'') {
+            *str = '\'';
+            ++p;
+        }
+
+        ++p;
+        ++str;
+        *str = *p;
+    }
+}
+
 void PrintJsonWithValueNull(const char * typeName, const char *yytext)
 {   
     PutComma();
@@ -210,7 +229,7 @@ BDIGIT  [01]
 BCONST  [BDIGIT]+[b]
 SYM_COMPLEX [F][0-9]+
 LOG_COMPLEX [L][0-9]+
-SCONST '(\\.^\\|[^\\'\n]|''|\\\\)+' 
+SCONST '(\\.^\\|[\\']|[^'\n]|''|\\\\)+'
 
 %%
     /*переменная*/
@@ -239,6 +258,8 @@ SCONST '(\\.^\\|[^\\'\n]|''|\\\\)+'
                     PrintJsonWithValueNull("quote", str);
                     int str_len = strlen(yytext) - 2;
                     str = strndup(yytext + 1, str_len);
+                    processSingleQuote(str);
+                    str_len = strlen(str);
                     PrintJsonWithValueString("sconst", str, str_len);
                     PrintJsonWithValueNull("quote", yytext + str_len);
                 }
@@ -370,7 +391,7 @@ int main(int argc, char *argv[])
     if(!program)
     {
         fprintf(stderr,"Incorrect JSON\n");
-        return 0;
+        return 1;
     }
     
     json_t *source_value = json_object_get(program, "source");


### PR DESCRIPTION
Баг:
https://github.com/tsu-iscd/lyapas-lcc/issues/94

Работают символы:
```
\t \n \\ \'
```

Можно проверить на примере:
test_escaping_chars.lyapas


Помимо этого:
1) lcc.sh завершает своё выполнение если один из промежуточных слоёв закончил работу с ошибкой.
2) im0 -> im1 теперь корректно выводит json (раньше проблемы были с экранируемыми символами)
3) im0 -> im1, lyapas -> im0 возвращают 1 в случае, если входной json содержит ошибку (раньше 0)